### PR TITLE
Enhance MKR IoT Carrier telemetry handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-﻿## per_gpt
+## per_gpt
+
+This sketch targets the Arduino MKR WiFi 1010 with the MKR IoT Carrier. It reads the onboard environment sensor, smooths the telemetry to minimise noise, logs the filtered values over the serial monitor, visualises the current temperature on the carrier's RGB LEDs, and persists the latest baseline readings in flash memory using the `FlashStorage` library.
+
+### Features
+- Initializes the MKR IoT Carrier and reports persisted baseline data on boot.
+- Samples temperature and humidity every two seconds, applies exponential smoothing, and prints the filtered results to the serial console.
+- Maps the smoothed temperature to a blue→red LED gradient so you can see changes at a glance without the LEDs being overly bright.
+- Stores new baseline readings in flash whenever the temperature or humidity drifts significantly from the saved values.
+- Lets you store a new baseline immediately by tapping touch pad 0 on the carrier, or clear the stored baseline with touch pad 4.
+
+### Requirements
+- [Arduino MKR WiFi 1010](https://store.arduino.cc/products/arduino-mkr-wifi-1010)
+- [Arduino MKR IoT Carrier](https://store.arduino.cc/products/arduino-mkr-iot-carrier)
+- Arduino libraries: `Arduino_MKRIoTCarrier`, `FlashStorage`
+
+### Build
+```bash
+arduino-cli core install arduino:samd
+arduino-cli lib install Arduino_MKRIoTCarrier FlashStorage
+arduino-cli compile --fqbn arduino:samd:mkrwifi1010 .
+```

--- a/per_gpt.ino
+++ b/per_gpt.ino
@@ -1,0 +1,185 @@
+#include <Arduino.h>
+#include <Arduino_MKRIoTCarrier.h>
+#include <FlashStorage.h>
+#include <math.h>
+
+struct PersistedEnvironment {
+  uint32_t signature;
+  float temperatureC;
+  float humidity;
+};
+
+constexpr uint32_t kPersistSignature = 0xA1B2C3D4;
+constexpr float kTemperatureDeltaToPersist = 0.5f;
+constexpr float kHumidityDeltaToPersist = 2.5f;
+constexpr unsigned long kTelemetryIntervalMs = 2000;
+constexpr unsigned long kPersistPauseMs = 30000;
+constexpr float kSmoothingFactor = 0.2f;
+
+FlashStorage(persistStore, PersistedEnvironment);
+
+MKRIoTCarrier carrier;
+PersistedEnvironment persisted = {};
+unsigned long lastTelemetry = 0;
+float smoothedTemperature = NAN;
+float smoothedHumidity = NAN;
+unsigned long skipAutoPersistUntil = 0;
+
+PersistedEnvironment loadPersistedEnvironment() {
+  PersistedEnvironment data = persistStore.read();
+  if (data.signature != kPersistSignature || !isfinite(data.temperatureC) || !isfinite(data.humidity)) {
+    data.signature = 0;
+    data.temperatureC = NAN;
+    data.humidity = NAN;
+  }
+  return data;
+}
+
+void persistEnvironment(float temperatureC, float humidity) {
+  persisted.signature = kPersistSignature;
+  persisted.temperatureC = temperatureC;
+  persisted.humidity = humidity;
+  persistStore.write(persisted);
+}
+
+void printPersistedEnvironment() {
+  if (persisted.signature != kPersistSignature) {
+    Serial.println("No persisted environment data found.");
+    return;
+  }
+  Serial.print("Last stored baseline -> Temperature: ");
+  Serial.print(persisted.temperatureC, 2);
+  Serial.print(" °C, Humidity: ");
+  Serial.print(persisted.humidity, 1);
+  Serial.println(" %");
+}
+
+void initializeCarrier() {
+  CARRIER_CASE = false;
+  if (!carrier.begin()) {
+    Serial.println("Failed to initialize MKR IoT Carrier!");
+    while (true) {
+      delay(1000);
+    }
+  }
+  carrier.Env.begin();
+  carrier.Buttons.begin();
+  carrier.leds.setBrightness(80);
+}
+
+void setup() {
+  Serial.begin(115200);
+  unsigned long start = millis();
+  while (!Serial && millis() - start < 2000) {
+    delay(10);
+  }
+
+  initializeCarrier();
+
+  persisted = loadPersistedEnvironment();
+  printPersistedEnvironment();
+}
+
+bool shouldPersist(float temperatureC, float humidity) {
+  if (persisted.signature != kPersistSignature) {
+    return true;
+  }
+
+  if (!isfinite(persisted.temperatureC) || !isfinite(persisted.humidity)) {
+    return true;
+  }
+
+  return fabs(temperatureC - persisted.temperatureC) >= kTemperatureDeltaToPersist ||
+         fabs(humidity - persisted.humidity) >= kHumidityDeltaToPersist;
+}
+
+void logEnvironment(float temperatureC, float humidity) {
+  Serial.print("Current -> Temperature: ");
+  Serial.print(temperatureC, 2);
+  Serial.print(" °C, Humidity: ");
+  Serial.print(humidity, 1);
+  Serial.println(" %");
+}
+
+void updateLed(float temperatureC) {
+  const float minTemp = 10.0f;
+  const float maxTemp = 35.0f;
+  float ratio = (temperatureC - minTemp) / (maxTemp - minTemp);
+  ratio = constrain(ratio, 0.0f, 1.0f);
+
+  uint8_t red = static_cast<uint8_t>(ratio * 255);
+  uint8_t blue = static_cast<uint8_t>((1.0f - ratio) * 255);
+
+  for (uint8_t i = 0; i < 5; ++i) {
+    carrier.leds.setPixelColor(i, carrier.leds.Color(red, 0, blue));
+  }
+  carrier.leds.show();
+}
+
+void updateSmoothing(float temperatureC, float humidity) {
+  if (!isfinite(smoothedTemperature)) {
+    smoothedTemperature = temperatureC;
+  } else {
+    smoothedTemperature = (kSmoothingFactor * temperatureC) +
+                          ((1.0f - kSmoothingFactor) * smoothedTemperature);
+  }
+
+  if (!isfinite(smoothedHumidity)) {
+    smoothedHumidity = humidity;
+  } else {
+    smoothedHumidity = (kSmoothingFactor * humidity) +
+                       ((1.0f - kSmoothingFactor) * smoothedHumidity);
+  }
+}
+
+void serviceTouchControls(float temperatureC, float humidity) {
+  carrier.Buttons.update();
+  if (carrier.Buttons.onTouchDown(TOUCH0)) {
+    Serial.println("Touch pad 0 pressed -> storing new baseline.");
+    persistEnvironment(temperatureC, humidity);
+    Serial.println("Persisted new baseline environment readings to flash.");
+    skipAutoPersistUntil = 0;
+  }
+
+  if (carrier.Buttons.onTouchDown(TOUCH4)) {
+    Serial.println("Touch pad 4 pressed -> clearing baseline from flash.");
+    persisted.signature = 0;
+    persisted.temperatureC = NAN;
+    persisted.humidity = NAN;
+    persistStore.write(persisted);
+    skipAutoPersistUntil = millis() + kPersistPauseMs;
+    Serial.println("Auto persistence paused for 30 seconds to allow conditions to stabilise.");
+  }
+}
+
+void loop() {
+  unsigned long now = millis();
+  if (now - lastTelemetry < kTelemetryIntervalMs) {
+    return;
+  }
+  lastTelemetry = now;
+
+  float temperatureC = carrier.Env.readTemperature();
+  float humidity = carrier.Env.readHumidity();
+
+  if (!isfinite(temperatureC) || !isfinite(humidity)) {
+    Serial.println("Failed to read environment sensor.");
+    return;
+  }
+
+  updateSmoothing(temperatureC, humidity);
+  logEnvironment(smoothedTemperature, smoothedHumidity);
+  updateLed(smoothedTemperature);
+
+  serviceTouchControls(smoothedTemperature, smoothedHumidity);
+
+  if (skipAutoPersistUntil != 0 && millis() < skipAutoPersistUntil) {
+    return;
+  }
+  skipAutoPersistUntil = 0;
+
+  if (shouldPersist(smoothedTemperature, smoothedHumidity)) {
+    persistEnvironment(smoothedTemperature, smoothedHumidity);
+    Serial.println("Persisted new baseline environment readings to flash.");
+  }
+}

--- a/src/main.ino
+++ b/src/main.ino
@@ -1,2 +1,0 @@
-﻿void setup(){ Serial.begin(115200); }
-void loop(){ Serial.println("ok"); delay(1000); }


### PR DESCRIPTION
## Summary
- smooth the MKR IoT Carrier environment readings before logging, LED updates, and persistence
- add touch controls to manually store or clear the persisted baseline and pause auto-persist after a clear
- document the new smoothing behaviour and touch interactions in the README

## Testing
- `arduino-cli compile --fqbn arduino:samd:mkrwifi1010 .` *(fails: `arduino-cli` is not available in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5cdee58c832a84aefee775f967f8